### PR TITLE
Adding eval support for chrome extensions

### DIFF
--- a/lib/polyfill-wrapper-end.js
+++ b/lib/polyfill-wrapper-end.js
@@ -6,6 +6,8 @@ var $__curScript, __eval;
 (function() {
 
   var doEval;
+  var isWorker = typeof window == 'undefined' && typeof self != 'undefined' && typeof importScripts != 'undefined';
+  var isBrowser = typeof window != 'undefined' && typeof document != 'undefined';
 
   __eval = function(source, address, sourceMap) {
     source += '\n//# sourceURL=' + address + (sourceMap ? '\n//# sourceMappingURL=' + sourceMap : '');
@@ -23,7 +25,31 @@ var $__curScript, __eval;
     }
   };
 
-  if (typeof document != 'undefined') {
+  if (isWorker || isBrowser && window.chrome && window.chrome.extension) {
+    doEval = function(source) {
+      try {
+        eval(source);
+      } catch(e) {
+        throw e;
+      }
+    };
+
+    if (!$__global.System || !$__global.LoaderPolyfill) {
+      var basePath = '';
+      try {
+        throw new Error('Get worker base path via error stack');
+      } catch (e) {
+        e.stack.replace(/(?:at|@).*(http.+):[\d]+:[\d]+/, function (m, url) {
+          basePath = url.replace(/\/[^\/]*$/, '/');
+        });
+      }
+      importScripts(basePath + 'steal-es6-module-loader.js');
+      $__global.upgradeSystemLoader();
+    } else {
+      $__global.upgradeSystemLoader();
+    }
+  }
+  else if (typeof document != 'undefined') {
     var head;
 
     var scripts = document.getElementsByTagName('script');
@@ -57,30 +83,6 @@ var $__curScript, __eval;
       );
     }
     else {
-      $__global.upgradeSystemLoader();
-    }
-  }
-  else if (typeof WorkerGlobalScope != 'undefined' && typeof importScripts != 'undefined') {
-    doEval = function(source) {
-      try {
-        eval(source);
-      } catch(e) {
-        throw e;
-      }
-    };
-
-    if (!$__global.System || !$__global.LoaderPolyfill) {
-      var basePath = '';
-      try {
-        throw new Error('Get worker base path via error stack');
-      } catch (e) {
-        e.stack.replace(/(?:at|@).*(http.+):[\d]+:[\d]+/, function (m, url) {
-          basePath = url.replace(/\/[^\/]*$/, '/');
-        });
-      }
-      importScripts(basePath + 'steal-es6-module-loader.js');
-      $__global.upgradeSystemLoader();
-    } else {
       $__global.upgradeSystemLoader();
     }
   }


### PR DESCRIPTION
Allows this fork of systemjs, and by extension StealJS, to be used in a chrome extension.

Incorporates the upstream [fix in 0.18.2](https://github.com/systemjs/systemjs/issues/531). The eval code has changed quite a bit upstream but the jist of the fix is:

- Add check for chrome environment (window.chrome && window.chrome.extension)
- Test for worker and extension first
