### PR TITLE
better AMD module detection

### DIFF
--- a/lib/extension-amd.js
+++ b/lib/extension-amd.js
@@ -14,8 +14,10 @@ function amd(loader) {
   // define(varName); || define(function(require, exports) {}); || define({})
   var amdRegEx = /(?:^\uFEFF?|[^$_a-zA-Z\xA0-\uFFFF.])define\s*\(\s*("[^"]+"\s*,\s*|'[^']+'\s*,\s*)?\s*(\[(\s*(("[^"]+"|'[^']+')\s*,|\/\/.*\r?\n|\/\*(.|\s)*?\*\/))*(\s*("[^"]+"|'[^']+')\s*,?)?(\s*(\/\/.*\r?\n|\/\*(.|\s)*?\*\/))*\s*\]|function\s*|{|[_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*\))/;
 
+  var strictCommentRegEx = /\/\*[\s\S]*?\*\/|([^:]|^)\/\/.*$/gm
   var commentRegEx = /(\/\*([\s\S]*?)\*\/|([^:]|^)\/\/(.*)$)/mg;
   var stringRegEx = /("[^"\\\n\r]*(\\.[^"\\\n\r]*)*"|'[^'\\\n\r]*(\\.[^'\\\n\r]*)*')/g;
+  var beforeRegEx = /(function|var|let|const|return|export|\"|\'|\(|\=)$/i
   var cjsRequirePre = "(?:^|[^$_a-zA-Z\\xA0-\\uFFFF.])";
   var cjsRequirePost = "\\s*\\(\\s*(\"([^\"]+)\"|'([^']+)')\\s*\\)";
   var fnBracketRegEx = /\(([^\)]*)\)/;
@@ -279,25 +281,36 @@ function amd(loader) {
 
   var loaderInstantiate = loader.instantiate;
   loader.instantiate = function(load) {
-    var loader = this;
+    var loader = this,
+      sourceWithoutComments = load.source.replace(strictCommentRegEx, '$1'),
+      match = sourceWithoutComments.match(amdRegEx);
 
-    if (load.metadata.format == 'amd' || !load.metadata.format && load.source.match(amdRegEx)) {
-      load.metadata.format = 'amd';
+    if (load.metadata.format == 'amd' || !load.metadata.format && match) {
 
-      if (loader.execute !== false) {
-        createDefine(loader);
+      // make sure that this is really a AMD module
+      // get the content from beginning till the matched define block
+      var sourceBeforeDefine = sourceWithoutComments.substring(0, sourceWithoutComments.indexOf(match[0])),
+        trimmed = sourceBeforeDefine.replace(wsRegEx, "")
 
-        loader.__exec(load);
+      // check if that there is no commen javscript keywork before
+      if (!beforeRegEx.test(trimmed)) {
+        load.metadata.format = 'amd';
 
-        removeDefine(loader);
+        if (loader.execute !== false) {
+          createDefine(loader);
 
-        if (!anonDefine && !defineBundle && !isNode)
-          throw new TypeError('AMD module ' + load.name + ' did not define');
-      }
+          loader.__exec(load);
 
-      if (anonDefine) {
-        load.metadata.deps = load.metadata.deps ? load.metadata.deps.concat(anonDefine.deps) : anonDefine.deps;
-        load.metadata.execute = anonDefine.execute;
+          removeDefine(loader);
+
+          if (!anonDefine && !defineBundle && !isNode)
+            throw new TypeError('AMD module ' + load.name + ' did not define');
+        }
+
+        if (anonDefine) {
+          load.metadata.deps = load.metadata.deps ? load.metadata.deps.concat(anonDefine.deps) : anonDefine.deps;
+          load.metadata.execute = anonDefine.execute;
+        }
       }
     }
 

--- a/test/test-babel.html
+++ b/test/test-babel.html
@@ -14,7 +14,7 @@
 		<div id="qunit-test-area"></div>
 
 		<!-- <script src="../bower_components/traceur/traceur.js"></script> -->
-		<script src="../node_modules/es6-module-loader/dist/es6-module-loader.src.js"></script>
+		<script src="../node_modules/steal-es6-module-loader/dist/es6-module-loader.src.js"></script>
 		<script src="../dist/system.src.js" type="text/javascript"></script>
 		<script>
 			System.paths['babel'] = '../node_modules/babel-core/browser.js';

--- a/test/test.js
+++ b/test/test.js
@@ -252,6 +252,27 @@ asyncTest('AMD cjs wrapper with comments', function() {
   }, err);
 });
 
+asyncTest('Not a AMD module', function() {
+  System['import']('tests/not-amd-module').then(function(m) {
+    equal(Object.getOwnPropertyNames(m).length, 0);
+    start();
+  }, err);
+});
+
+asyncTest('Not a AMD module within a if statement', function() {
+  System['import']('tests/not-amd-module2').then(function(m) {
+    equal(Object.getOwnPropertyNames(m).length, 0);
+    start();
+  }, err);
+});
+
+asyncTest('Not a AMD module after javascript keywords', function() {
+  System['import']('tests/not-amd-module3').then(function(m) {
+    equal(Object.getOwnPropertyNames(m).length, 0);
+    start();
+  }, err);
+});
+
 asyncTest('AMD detection test with byte order mark (BOM)', function() {
   System['import']('tests/amd-module-bom').then(function(m) {
     ok(m.amd);

--- a/test/tests/amd-module-3.js
+++ b/test/tests/amd-module-3.js
@@ -1,4 +1,6 @@
-define([
+/*
+some comment at the beginning
+*/define([
   // with a single-line comment
   './amd-module',
   /* with a multi-line

--- a/test/tests/not-amd-module.js
+++ b/test/tests/not-amd-module.js
@@ -1,0 +1,5 @@
+function makeDefinition(bar) {
+  return function define (bar) {
+    return "is not a AMD module"
+  }
+}

--- a/test/tests/not-amd-module2.js
+++ b/test/tests/not-amd-module2.js
@@ -1,0 +1,9 @@
+function makeDefinition(bar) {
+  var bar = "foo";
+  if( define(bar) === "foo"){
+    return "is not a AMD module"
+  }
+}
+function define(foo) {
+  return foo
+}

--- a/test/tests/not-amd-module3.js
+++ b/test/tests/not-amd-module3.js
@@ -1,0 +1,6 @@
+var bar = "foo";
+var foo = define(bar);
+
+function define(foo) {
+  return foo
+}

--- a/test/tests/worker-babel.js
+++ b/test/tests/worker-babel.js
@@ -1,4 +1,4 @@
-importScripts('../../node_modules/es6-module-loader/dist/es6-module-loader.js',
+importScripts('../../node_modules/steal-es6-module-loader/dist/es6-module-loader.js',
               '../../dist/system.js');
 
 System.baseURL = '../';

--- a/test/tests/worker-traceur.js
+++ b/test/tests/worker-traceur.js
@@ -1,4 +1,4 @@
-importScripts('../../node_modules/es6-module-loader/dist/es6-module-loader.js',
+importScripts('../../node_modules/steal-es6-module-loader/dist/es6-module-loader.js',
               '../../dist/system.js');
 
 System.baseURL = '../';


### PR DESCRIPTION
detect AMD modules better and do not false positive with the `define` keyword

@matthewp have to rewrite the code
now i check against this regex `/(function|var|let|const|return|export|\"|\'|\(|\=)$/` which means that before `define` this javascript keywords does not exists https://github.com/stealjs/systemjs/blob/better-amd-detection/lib/extension-amd.js#L296. there are only a few keywords but i think this will match 99%