### PR TITLE
check config property to be a object before deep merge

### DIFF
--- a/lib/extension-core.js
+++ b/lib/extension-core.js
@@ -56,7 +56,7 @@ function core(loader) {
     for (var c in cfg) {
       var v = cfg[c];
       if (typeof v == 'object' && !(v instanceof Array)) {
-        this[c] = this[c] || {};
+        this[c] = typeof this[c] === 'object' ? this[c] : {};
         for (var p in v)
           this[c][p] = v[p];
       }


### PR DESCRIPTION
before this PR this will not work
**first configuration**
```
				this.loader.config({
					cachebust: true
				});
```

**second configuration**
```
				loader.config({
					cachebust: {
						key: 'foo',
						version: 'bar'
					}
				});
```